### PR TITLE
Parse API timestamps as UTC and handle expired ports

### DIFF
--- a/PyIA/pia_api.py
+++ b/PyIA/pia_api.py
@@ -36,9 +36,9 @@ class ApiException(RuntimeError):
 class PiaApi:
     """Class to interface with PIA's APIs."""
 
-    TOKEN_LIFE_SECONDS = 3600  # 1 hour
+    TOKEN_LIFE_SECONDS = 1 * 60 * 60  # 1 hour
     TOKEN_ADDRESS = "https://www.privateinternetaccess.com/gtoken/generateToken"
-    REGION_LIFE_SECONDS = 43200  # 12 hours
+    REGION_LIFE_SECONDS = 12 * 60 * 60  # 12 hours
     REGION_ADDRESS = "https://serverlist.piaservers.net/vpninfo/servers/v6"
     SSL_CERT_ADDRESS = "https://raw.githubusercontent.com/pia-foss/manual-connections/master/ca.rsa.4096.crt"
     PORT_TEMPLATE = "{{PORT}}"

--- a/PyIA/vpn_data.py
+++ b/PyIA/vpn_data.py
@@ -101,8 +101,8 @@ class PersistentData(yaml.YAMLObject):
         return not_expired and self.token
 
     def payloadValid(self) -> bool:
-        """Checks if there is a port-forwarind payload and signature present, if
-        the payload is in the correct format, and if it is not expired
+        """Checks if there is a port-forwarding payload and signature present,
+        if the payload is in the correct format, and if it is not expired
 
         Returns:
             bool: True if the payload and signature are present and valid
@@ -113,7 +113,9 @@ class PersistentData(yaml.YAMLObject):
             data = json.loads(base64.b64decode(self.payload).decode("utf-8"))
             not_expired = (
                 time.time()
-                < datetime.datetime.fromisoformat(data["expires_at"][:-4]).timestamp()
+                < datetime.datetime.strptime(
+                    data["expires_at"][:-4] + "+0000", "%Y-%m-%dT%H:%M:%S.%f%z"
+                ).timestamp()
             )
         except Exception:
             return False

--- a/tests/test_pia_api.py
+++ b/tests/test_pia_api.py
@@ -247,6 +247,28 @@ class TestPiaApi:
         with pytest.raises(PyIA.ApiException):
             self.api.portForward()
 
+    def test_pfBindExpiredRetry(self, requests_mock: MockRequest):
+        requests_mock.get(self.api.REGION_ADDRESS, json=SAMPLE_REGIONS)
+        requests_mock.get(self.api.TOKEN_ADDRESS, json={"status": "OK", "token": "key"})
+        requests_mock.get("https://0.0.0.0:1337/addKey", json=AUTH_RESPONSE)
+        mock = requests_mock.get("https://0.0.0.0:19999/getSignature", json=SIGNATURE_RESPONSE)
+        requests_mock.get(
+            "https://0.0.0.0:19999/bindPort",
+            [
+                {
+                    "json": {"status": "error", "message": "port expired"},
+                    "status_code": 400,
+                },
+                {
+                    "json": {"status": "OK", "message": "bind success"},
+                    "status_code": 200,
+                },
+            ],
+        )
+        self.api.authenticate("testid0", "")
+        self.api.portForward()
+        assert mock.call_count == 2
+
     def test_pfBindFail(self, requests_mock: MockRequest):
         requests_mock.get(self.api.REGION_ADDRESS, json=SAMPLE_REGIONS)
         requests_mock.get(self.api.TOKEN_ADDRESS, json={"status": "OK", "token": "key"})

--- a/tests/test_pia_api.py
+++ b/tests/test_pia_api.py
@@ -61,7 +61,7 @@ SIGNATURE_RESPONSE = {
             {
                 "signature": "sig",
                 "expires_at": (
-                    datetime.datetime.now() + datetime.timedelta(0, 600)
+                    datetime.datetime.utcnow() + datetime.timedelta(0, 600)
                 ).isoformat()
                 + "000Z",
                 "port": 12345,

--- a/tests/test_vpn_data.py
+++ b/tests/test_vpn_data.py
@@ -97,7 +97,7 @@ def test_payloadValid():
                 {
                     "signature": "sig",
                     "expires_at": (
-                        datetime.datetime.now() + datetime.timedelta(0, 60)
+                        datetime.datetime.utcnow() + datetime.timedelta(0, 60)
                     ).isoformat()
                     + "000Z",
                 }
@@ -120,7 +120,7 @@ def test_portValid():
                 {
                     "signature": "sig",
                     "expires_at": (
-                        datetime.datetime.now() + datetime.timedelta(0, 60)
+                        datetime.datetime.utcnow() + datetime.timedelta(0, 60)
                     ).isoformat()
                     + "000Z",
                     "port": 12345,


### PR DESCRIPTION
- The timestamp used to be parsed with `datetime.fromisonformat()`, which was timezone naive. Now parsed with `datetime.strptime()` with the timezone fixed to UTC.
- Added check for the `port expired` bind response and immediately retry the port forwarding process if it occurs.
- The unit tests were updated to mock the UTC time like the API actually uses.
- A test was added to make sure a `port expired` response triggers a retry.

Closes #1 